### PR TITLE
fix: gap size between text and icon

### DIFF
--- a/src/components/pages/Shop/components/ProductCompare/Compare/CompareItem.tsx
+++ b/src/components/pages/Shop/components/ProductCompare/Compare/CompareItem.tsx
@@ -103,12 +103,9 @@ export const CompareItem: FC<CompareItemProps> = (props) => {
         </Link>
 
         <Link to={productDetailUrl}>
-          <Button
-            variant="text"
-            {...buttonProp}
-            rightIcon={<ChevronRightIcon width={24} height={24} />}
-          >
+          <Button variant="text" {...buttonProp}>
             <I18n name="action__learn_more" />
+            <ChevronRightIcon width={24} height={24} />
           </Button>
         </Link>
       </Flex>


### PR DESCRIPTION
## Preview

https://onekey-portal-git-feature-adjust-gap-limichange.vercel.app/shop/

![CleanShot 2022-08-01 at 17 39 45@2x](https://user-images.githubusercontent.com/1947344/182120477-baa1544e-0438-4574-8804-f480f1899e6d.jpg)

