### PR TITLE
fix: shop link i18n error

### DIFF
--- a/src/components/base/GoToShopButton/GoToShopButton.tsx
+++ b/src/components/base/GoToShopButton/GoToShopButton.tsx
@@ -1,9 +1,9 @@
 import { AnchorHTMLAttributes, FC, ReactNode } from 'react';
 
-import { navigate } from 'gatsby';
 import { useTranslation } from 'gatsby-plugin-react-i18next';
 
 import { Button, ButtonProps } from '../Button';
+import { Link } from '../Link';
 
 export interface GoToShopButtonProps {
   children?: ReactNode;
@@ -27,15 +27,11 @@ export const GoToShopButton: FC<GoToShopButtonProps> = (props) => {
   const { button: buttonOverrides = {} } = overrides;
 
   return (
-    <Button
-      onClick={() => {
-        navigate('/shop');
-      }}
-      variant="outlined"
-      {...buttonOverrides}
-    >
-      {t('action__go_to_shop')}
-      {children}
-    </Button>
+    <Link to="/shop">
+      <Button variant="outlined" {...buttonOverrides}>
+        {t('action__go_to_shop')}
+        {children}
+      </Button>
+    </Link>
   );
 };


### PR DESCRIPTION
## Description

The shop i18n router didn't really work because we were using gatsby `navigate`, which has been fixed now.

## Preview

https://onekey-portal-git-fix-shop-url-limichange.vercel.app/
https://onekey-portal-git-fix-shop-url-limichange.vercel.app/zh_CN/