### PR TITLE
fix: incorrect canvas height

### DIFF
--- a/src/components/pages/Home/components/Feature/Feature.tsx
+++ b/src/components/pages/Home/components/Feature/Feature.tsx
@@ -1,7 +1,6 @@
 import { FC, ReactNode } from 'react';
 
-import { useMediaQuery } from '../../../../../hooks';
-import { Box } from '../../../../base';
+import { Box, OnlyDisplay } from '../../../../base';
 
 import { MobileFeatureSection } from './MobileFeatureSection';
 import { NormalFeatureSection } from './NormalFeatureSection';
@@ -12,12 +11,16 @@ export interface FeatureProps {
 
 export const Feature: FC<FeatureProps> = (props) => {
   const { children } = props;
-  const mediaQuery = useMediaQuery();
 
   return (
     <Box>
-      {mediaQuery.medium && <NormalFeatureSection />}
-      {!mediaQuery.medium && <MobileFeatureSection />}
+      <OnlyDisplay m l xl xxl>
+        <NormalFeatureSection />
+      </OnlyDisplay>
+
+      <OnlyDisplay xs s>
+        <MobileFeatureSection />
+      </OnlyDisplay>
 
       {children}
     </Box>

--- a/src/components/pages/Home/components/Feature/NormalFeatureSection/NormalFeatureSection.tsx
+++ b/src/components/pages/Home/components/Feature/NormalFeatureSection/NormalFeatureSection.tsx
@@ -70,7 +70,9 @@ export const NormalFeatureSection: FC<NormalFeatureSectionProps> = () => {
           <CanvasPlayer
             frame={parseInt(motionValue.get().toFixed(0))}
             width={windowWidth || 0}
-            height={(960 / 2880) * (windowWidth || 0)}
+            height={
+              parseInt(((960 / 2880) * (windowWidth || 0)).toFixed(0)) - 1
+            }
             images={new Array(30)
               .fill('')
               .map((_, index) =>

--- a/src/components/pages/Home/components/Feature/NormalFeatureSection/NormalFeatureSection.tsx
+++ b/src/components/pages/Home/components/Feature/NormalFeatureSection/NormalFeatureSection.tsx
@@ -70,9 +70,7 @@ export const NormalFeatureSection: FC<NormalFeatureSectionProps> = () => {
           <CanvasPlayer
             frame={parseInt(motionValue.get().toFixed(0))}
             width={windowWidth || 0}
-            height={
-              parseInt(((960 / 2880) * (windowWidth || 0)).toFixed(0)) - 1
-            }
+            height={parseInt(((960 / 2880) * (windowWidth || 0)).toFixed(0))}
             images={new Array(30)
               .fill('')
               .map((_, index) =>


### PR DESCRIPTION
## Description

The fractional issue causes a white border to appear in certain browser width.

## Preview

https://onekey-portal-git-fix-issue-249-limichange.vercel.app/

## Refs

https://github.com/OneKeyHQ/portal/issues/249